### PR TITLE
Fix version detection

### DIFF
--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -42,8 +42,8 @@ export default function ({ title, labels = [], config = [], dependencies = {} })
   }
 
   // extract version from the title, allowing for constraints (~,^,>=) and v prefix
-  const from = title.match(new RegExp('from \\D*' + regex.semver.source))?.groups
-  const to = title.match(new RegExp('to \\D*' + regex.semver.source))?.groups
+  const from = title.match(new RegExp(' from \\D*' + regex.semver.source))?.groups
+  const to = title.match(new RegExp(' to \\D*' + regex.semver.source))?.groups
 
   if (!to) {
     core.warning('failed to parse title: no recognizable versions')


### PR DESCRIPTION
The current version detection fails since it's not strict enough. For example,
given the PR title "Bump @fontsource/lato from 4.5.5 to 4.5.8": Both "from"
and "to" versions are parsed as "4.5.5.", because the word "to" is included
in the dependency name as well.

Therefore, the corresponding regexes have been adapted to enforce a
whitespace prior to the "from" and "to" terms.